### PR TITLE
Fix css example in weasyprint README.md

### DIFF
--- a/weasyprint/README.md
+++ b/weasyprint/README.md
@@ -36,4 +36,4 @@ Example payload to print pdf from url and return link to s3:
 
 Example paylod to print png from html and css data and return png content encoded in base64:
 
-    {"html": "<html><h1>Header</h1></html>", "css": ["h1 { color: red }"], "filename": "report.png", "return": "base64"}
+    {"html": "<html><h1>Header</h1></html>", "css": "h1 { color: red }", "filename": "report.png", "return": "base64"}


### PR DESCRIPTION
Using the example as is produces the following error:

```
[ERROR] AttributeError: 'str' object has no attribute 'type'
Traceback (most recent call last):
  File "/var/task/weasyprint/lambda_function.py", line 26, in lambda_handler
    stylesheets=[CSS(string=event["css"])] if "css" in event else None,
  File "/opt/python/lib/python3.8/site-packages/weasyprint/__init__.py", line 359, in __init__
    stylesheet = tinycss2.parse_stylesheet(source)
  File "/opt/python/lib/python3.8/site-packages/tinycss2/parser.py", line 307, in parse_stylesheet
    if token.type == 'whitespace':
```

I was able to replicate the same issue in tinycss2 by installing the latest published version and (`1.1.0`)  and runnnig:


```
>>> tinycss2.parse_stylesheet(["h1 { color: red }"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/anaconda3/lib/python3.7/site-packages/tinycss2/parser.py", line 307, in parse_stylesheet
    if token.type == 'whitespace':
AttributeError: 'str' object has no attribute 'type'
```

Which does not happen when running:

```
>>> tinycss2.parse_stylesheet("h1 { color: red }")
[<QualifiedRule … { … }>]
```

The same change (not wrapping the style in a list) also fixes the error during lambda execution.   

Please confirm the error isn't isolated to my lambda environment (though having identified the root cause and reproduced on a local python environment I'm pretty confident it is not) and merge if deemed relevant 😃  