### PR TITLE
Fix examples in weasyprint README.md

### DIFF
--- a/weasyprint/README.md
+++ b/weasyprint/README.md
@@ -48,8 +48,8 @@ it requires `BUCKET=<bucket name>` env variable if files stored on s3.
 
 Example payload to print pdf from url and return link to s3:
 
-    {"url": "https://weasyprint.org/samples/report/report.html", "filename": "report.pdf"}
+    {"url": "https://kotify.github.io/cloud-print-utils/samples/report/", "filename": "report.pdf"}
 
-Example paylod to print png from html and css data and return png content encoded in base64:
+Example paylod to print pdf from html and css data and return pdf content encoded in base64:
 
-    {"html": "<html><h1>Header</h1></html>", "css": "h1 { color: red }", "filename": "report.png", "return": "base64"}
+    {"html": "<html><h1>Header</h1></html>", "css": "h1 { color: red }", "filename": "report.pdf", "return": "base64"}


### PR DESCRIPTION
I updated: 

- The url example is raising a 404, I updated to the one from the test.
- PNG example is raising error as it's no more directly supported from version 53. More detail here: https://www.courtbouillon.org/blog/00009-weasyprint-53-what-s-new.

Please confirm the errors and merge if need.

Not related with this PR but wkhtmltopdf status turn to public archive on github:
https://github.com/wkhtmltopdf/wkhtmltopdf
More details about in this issue:
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/5160

Better to leave a note on the different readme or remove completely the links.