### PR TITLE
python3.12 layer published with SAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ stack.deploy:
 	cd cdk-stacks && npm install && npm run build
 	cdk deploy --app ./cdk-stacks/bin/app.js --stack PrintStack --parameters uploadBucketName=${BUCKET}
 
+cfn.deploy: build/weasyprint-layer-python$(RUNTIME).zip
+	@echo "Deploying the weasyprint PDF Layer using SAM"
+	@sam deploy \
+		--resolve-s3 \
+		--template-file weasyprintlayer.yaml \
+		--stack-name PDFLayer \
+		--region eu-west-1
+
 test.start.container:
 	${DOCKER_RUN} \
 	    -e GDK_PIXBUF_MODULE_FILE="/opt/lib/loaders.cache" \

--- a/weasyprint/Dockerfile
+++ b/weasyprint/Dockerfile
@@ -1,6 +1,6 @@
 # Define global args
 ARG FUNCTION_DIR="/home/app/"
-ARG RUNTIME_VERSION="3.11"
+ARG RUNTIME_VERSION="3.12"
 ARG DISTRO_VERSION="3.18"
 
 # Stage 1 - bundle base image + runtime

--- a/weasyprintlayer.yaml
+++ b/weasyprintlayer.yaml
@@ -1,0 +1,20 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Description: |
+  The weasyprint (html->pdf) Layer.
+
+Resources:
+
+  PDFLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: weasyprintLayer
+      Description: PDF manipulation layer.
+      ContentUri: build/weasyprint-layer-python3.12.zip
+      CompatibleRuntimes:
+        - python3.12
+      CompatibleArchitectures:
+        - x86_64
+  


### PR DESCRIPTION
Added a Makefile entry to deploy weasyprint layer using CloudFormation/SAM for python3.12.

To deploy the layer:

`make cfn.deploy`

This will deploy a lambda layer with weasyprint support in your account. The layer can be referenced as ```weasyprintLayer``` for use in your lambda functions.