### PR TITLE
Add note on requirement for x86_64 instruction set architecture.

### DIFF
--- a/weasyprint/README.md
+++ b/weasyprint/README.md
@@ -30,6 +30,8 @@ Lambda must be configured with these env vars:
     FONTCONFIG_PATH="/opt/fonts"
     XDG_DATA_DIRS="/opt/lib"
 
+Ensure your Lambda instruction set architecture is set to `x86_64`, as `arm64` is not currently supported as a build type.
+
 ## Docker Lambda
 
 Build layer:

--- a/weasyprint/README.md
+++ b/weasyprint/README.md
@@ -30,7 +30,7 @@ Lambda must be configured with these env vars:
     FONTCONFIG_PATH="/opt/fonts"
     XDG_DATA_DIRS="/opt/lib"
 
-Ensure your Lambda instruction set architecture is set to `x86_64`, as `arm64` is not currently supported as a build type.
+If you are using the release zip files ensure your Lambda instruction set architecture is set to `x86_64` and not `arm64`.
 
 ## Docker Lambda
 


### PR DESCRIPTION
Based on my experience of not being able to get weasyprint to work as a layer, because I was using arm64 instead of x86_64, have added a clarifying note where I think people will see it. 