### PR TITLE
Add Arm64 Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,8 @@ jobs:
     strategy:
       matrix:
         version: ["3.12", "3.13"]
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
-        include:
-          - os: ubuntu-24.04
-            arch: x86_x64
-          - os: ubuntu-24.04-arm
-            arch: arm64
-    runs-on: ${{ matrix.os }}
+        arch: ["x86_64", "arm64"]
+    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     env:
       RUNTIME: ${{ matrix.version }}
       ARCH: ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Upload Build
         uses: actions/upload-artifact@v4
         with:
-          name: WeasyPrint Layer Build ${{ matrix.version }}
+          name: WeasyPrint Layer Build ${{ matrix.version }} arm64
           path: build
   weasyprint-build-x86_64:
     name: Build WeasyPrint x86_64
@@ -56,7 +56,7 @@ jobs:
       - name: Upload Build
         uses: actions/upload-artifact@v4
         with:
-          name: WeasyPrint Layer Build ${{ matrix.version }}
+          name: WeasyPrint Layer Build ${{ matrix.version }} x86_64
           path: build
   weasyprint-release:
     name: Release WeasyPrint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,20 @@ name: Build and Release
 on: push
 
 jobs:
-  weasyprint-build:
-    name: Build WeasyPrint
+  weasyprint-build-arm64:
+    name: Build WeasyPrint arm64
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        version: ["3.12"]
+        version: ["3.12", "3.13"]
     env:
       RUNTIME: ${{ matrix.version }}
+      PLATFORM: linux/arm64
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v4
       - name: Build Layer 
-        run: make build/weasyprint-layer-python${{ matrix.version }}.zip
+        run: make build/weasyprint-layer-python${{ matrix.version }}-arm64.zip
       - name: Test weasyprint
         run: |
           mkdir output
@@ -22,7 +24,35 @@ jobs:
           make test.print.report
           rm -rf build/opt
         env:
-          TEST_FILENAME: build/test-report-${{ matrix.version }}.pdf 
+          TEST_FILENAME: build/test-report-${{ matrix.version }}-arm64.pdf 
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: WeasyPrint Layer Build ${{ matrix.version }}
+          path: build
+  weasyprint-build-x86_64:
+    name: Build WeasyPrint x86_64
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        version: ["3.12", "3.13"]
+    env:
+      RUNTIME: ${{ matrix.version }}
+      PLATFORM: linux/amd64
+      ARCH: x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Layer 
+        run: make build/weasyprint-layer-python${{ matrix.version }}-x86_64.zip
+      - name: Test weasyprint
+        run: |
+          mkdir output
+          make test.start.container &
+          sleep 1
+          make test.print.report
+          rm -rf build/opt
+        env:
+          TEST_FILENAME: build/test-report-${{ matrix.version }}-x86_64.pdf 
       - name: Upload Build
         uses: actions/upload-artifact@v4
         with:
@@ -31,7 +61,7 @@ jobs:
   weasyprint-release:
     name: Release WeasyPrint
     runs-on: ubuntu-24.04-arm
-    needs: [weasyprint-build]
+    needs: [weasyprint-build-arm64, weasyprint-build-x86_64]
     if: startsWith(github.ref, 'refs/tags/weasyprint-')
     steps:
       - name: Download build
@@ -42,3 +72,23 @@ jobs:
         uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           files: ./artifacts/**/weasyprint-layer-python*
+
+  ghostscript-build:
+    name: Build GhostScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Layer
+        run: |
+          make build/ghostscript-layer.zip
+          rm -rf build/opt
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: GhostScript Layer Build
+          path: build
+      - name: Create GhostScript Release
+        if: startsWith(github.ref, 'refs/tags/ghostscript-')
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
+        with:
+          files: ./build/ghostscript-layer.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on: push
 jobs:
   weasyprint-build:
     name: Build WeasyPrint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        version: ["3.12", "3.13"]
+        version: ["3.12"]
     env:
       RUNTIME: ${{ matrix.version }}
     steps:
@@ -30,7 +30,7 @@ jobs:
           path: build
   weasyprint-release:
     name: Release WeasyPrint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [weasyprint-build]
     if: startsWith(github.ref, 'refs/tags/weasyprint-')
     steps:
@@ -42,23 +42,3 @@ jobs:
         uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           files: ./artifacts/**/weasyprint-layer-python*
-
-  ghostscript-build:
-    name: Build GhostScript
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Layer
-        run: |
-          make build/ghostscript-layer.zip
-          rm -rf build/opt
-      - name: Upload Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: GhostScript Layer Build
-          path: build
-      - name: Create GhostScript Release
-        if: startsWith(github.ref, 'refs/tags/ghostscript-')
-        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
-        with:
-          files: ./build/ghostscript-layer.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,25 @@ name: Build and Release
 on: push
 
 jobs:
-  weasyprint-build-arm64:
-    name: Build WeasyPrint arm64
-    runs-on: ubuntu-24.04-arm
+  weasyprint-build:
+    name: Build WeasyPrint
     strategy:
       matrix:
         version: ["3.12", "3.13"]
+        os: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        include:
+          - os: ubuntu-24.04
+            arch: x86_x64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     env:
       RUNTIME: ${{ matrix.version }}
-      PLATFORM: linux/arm64
-      ARCH: arm64
+      ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Layer 
-        run: make build/weasyprint-layer-python${{ matrix.version }}-arm64.zip
+        run: make build/weasyprint-layer-python${{ matrix.version }}-${{ matrix.arch }}.zip
       - name: Test weasyprint
         run: |
           mkdir output
@@ -24,44 +29,16 @@ jobs:
           make test.print.report
           rm -rf build/opt
         env:
-          TEST_FILENAME: build/test-report-${{ matrix.version }}-arm64.pdf 
+          TEST_FILENAME: build/test-report-${{ matrix.version }}-${{ matrix.arch }}.pdf 
       - name: Upload Build
         uses: actions/upload-artifact@v4
         with:
-          name: WeasyPrint Layer Build ${{ matrix.version }} arm64
-          path: build
-  weasyprint-build-x86_64:
-    name: Build WeasyPrint x86_64
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        version: ["3.12", "3.13"]
-    env:
-      RUNTIME: ${{ matrix.version }}
-      PLATFORM: linux/amd64
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Layer 
-        run: make build/weasyprint-layer-python${{ matrix.version }}-x86_64.zip
-      - name: Test weasyprint
-        run: |
-          mkdir output
-          make test.start.container &
-          sleep 1
-          make test.print.report
-          rm -rf build/opt
-        env:
-          TEST_FILENAME: build/test-report-${{ matrix.version }}-x86_64.pdf 
-      - name: Upload Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: WeasyPrint Layer Build ${{ matrix.version }} x86_64
+          name: WeasyPrint Layer Build ${{ matrix.version }} ${{ matrix.arch }}
           path: build
   weasyprint-release:
     name: Release WeasyPrint
-    runs-on: ubuntu-24.04-arm
-    needs: [weasyprint-build-arm64, weasyprint-build-x86_64]
+    runs-on: ubuntu-latest
+    needs: [weasyprint-build]
     if: startsWith(github.ref, 'refs/tags/weasyprint-')
     steps:
       - name: Download build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_RUN=docker run --rm --platform=${PLATFORM} -e RUNTIME_VERSION=${RUNTIME}
 
 .PHONY: stack.deploy.weasyprint clean test.start.container test.print.report
 
-all: build/weasyprint-layer-python$(RUNTIME)$(ARCH).zip
+all: build/weasyprint-layer-python$(RUNTIME)-$(ARCH).zip
 
 build/weasyprint-layer-python$(RUNTIME)-$(ARCH).zip: weasyprint/layer_builder.sh \
     build/fonts-layer.zip \
@@ -15,11 +15,11 @@ build/weasyprint-layer-python$(RUNTIME)-$(ARCH).zip: weasyprint/layer_builder.sh
 	    -v `pwd`/weasyprint:/out \
 			--entrypoint "/out/layer_builder.sh" \
 	    -t public.ecr.aws/lambda/python:${RUNTIME} 
-	mv -f ./weasyprint/layer.zip ./build/weasyprint-layer-python${RUNTIME}${ARCH}-no-fonts.zip
+	mv -f ./weasyprint/layer.zip ./build/weasyprint-layer-python${RUNTIME}-${ARCH}-no-fonts.zip
 	cd build && rm -rf ./opt && mkdir opt \
 	    && unzip fonts-layer.zip -d opt \
 	    && unzip weasyprint-layer-python${RUNTIME}${ARCH}-no-fonts.zip -d opt \
-	    && cd opt && zip -r9 ../weasyprint-layer-python${RUNTIME}${ARCH}.zip .
+	    && cd opt && zip -r9 ../weasyprint-layer-python${RUNTIME}-${ARCH}.zip .
 
 build/fonts-layer.zip: fonts/layer_builder.sh | _build
 	${DOCKER_RUN} \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_RUN=docker run --rm --platform=${PLATFORM} -e RUNTIME_VERSION=${RUNTIME}
 
 all: build/weasyprint-layer-python$(RUNTIME)$(ARCH).zip
 
-build/weasyprint-layer-python$(RUNTIME)$(ARCH).zip: weasyprint/layer_builder.sh \
+build/weasyprint-layer-python$(RUNTIME)-$(ARCH).zip: weasyprint/layer_builder.sh \
     build/fonts-layer.zip \
     | _build
 	${DOCKER_RUN} \
@@ -43,7 +43,7 @@ stack.deploy:
 	cd cdk-stacks && npm install && npm run build
 	cdk deploy --app ./cdk-stacks/bin/app.js --stack PrintStack --parameters uploadBucketName=${BUCKET}
 
-test.start.container: build/weasyprint-layer-python$(RUNTIME)$(ARCH).zip
+test.start.container: build/weasyprint-layer-python$(RUNTIME)-$(ARCH).zip
 	${DOCKER_RUN} \
 	    -e FONTCONFIG_PATH="/opt/fonts" \
 	    -e LD_LIBRARY_PATH="/opt/lib" \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-PLATFORM ?= linux/amd64
 RUNTIME ?= 3.12
 ARCH ?= x86_64
 TEST_FILENAME ?= report.pdf
 DOCKER_RUN=docker run --rm --platform=${PLATFORM} -e RUNTIME_VERSION=${RUNTIME}
+
+ifeq ($(ARCH), arm64)
+ PLATFORM=linux/arm64
+else
+ PLATFORM=linux/amd64
+endif
 
 .PHONY: stack.deploy.weasyprint clean test.start.container test.print.report
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build/fonts-layer.zip: fonts/layer_builder.sh | _build
 	${DOCKER_RUN} \
 	    -v `pwd`/fonts:/out \
 	    --entrypoint "/out/layer_builder.sh" \
-	    -t public.ecr.aws/lambda/python:${RUNTIME} 
+	    -t public.ecr.aws/lambda/python:${RUNTIME}-arm64 
 	mv -f ./fonts/layer.zip $@
 
 build/ghostscript-layer.zip: ghostscript/layer_builder.sh | _build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build/weasyprint-layer-python$(RUNTIME).zip: weasyprint/layer_builder.sh \
 	${DOCKER_RUN} \
 	    -v `pwd`/weasyprint:/out \
 			--entrypoint "/out/layer_builder.sh" \
-	    -t public.ecr.aws/lambda/python:${RUNTIME} 
+	    -t public.ecr.aws/lambda/python:${RUNTIME}-arm64 
 	mv -f ./weasyprint/layer.zip ./build/weasyprint-layer-python${RUNTIME}-no-fonts.zip
 	cd build && rm -rf ./opt && mkdir opt \
 	    && unzip fonts-layer.zip -d opt \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORM ?= linux/amd64
+PLATFORM ?= linux/arm64
 RUNTIME ?= 3.12
 TEST_FILENAME ?= report.pdf
 DOCKER_RUN=docker run --rm --platform=${PLATFORM} -e RUNTIME_VERSION=${RUNTIME}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build/weasyprint-layer-python$(RUNTIME)-$(ARCH).zip: weasyprint/layer_builder.sh
 	mv -f ./weasyprint/layer.zip ./build/weasyprint-layer-python${RUNTIME}-${ARCH}-no-fonts.zip
 	cd build && rm -rf ./opt && mkdir opt \
 	    && unzip fonts-layer.zip -d opt \
-	    && unzip weasyprint-layer-python${RUNTIME}${ARCH}-no-fonts.zip -d opt \
+	    && unzip weasyprint-layer-python${RUNTIME}-${ARCH}-no-fonts.zip -d opt \
 	    && cd opt && zip -r9 ../weasyprint-layer-python${RUNTIME}-${ARCH}.zip .
 
 build/fonts-layer.zip: fonts/layer_builder.sh | _build

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ Deploy layer:
 
 Lambda must be configured with these env vars:
 
-    GDK_PIXBUF_MODULE_FILE="/opt/lib/loaders.cache"
+    LD_LIBRARY_PATH="/opt/lib"
     FONTCONFIG_PATH="/opt/fonts"
-    XDG_DATA_DIRS="/opt/lib"
 
 arm64 is also supported! Use the arm64 zip under Releases or build using "make build/weasyprint-layer-python3.12-arm64.zip"
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Lambda must be configured with these env vars:
     LD_LIBRARY_PATH="/opt/lib"
     FONTCONFIG_PATH="/opt/fonts"
 
-arm64 is also supported! Use the arm64 zip under Releases or build using "make build/weasyprint-layer-python3.12-arm64.zip"
+arm64 is also supported! Use the arm64 zip under Releases or build using "ARCH=arm64 make build/weasyprint-layer-python3.12-arm64.zip"
 
 To build a layer for python3.13 runime use:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a collection of AWS Lambda layers and functions to render pdf documents and images from HTML.
 
 Download layers from release section or build them yourself (requires: make, docker, zip, unzip, jq).
-The layers support only Amazon Linux 2023 runtimes, eg. python3.12.
+The layers support only Amazon Linux 2023 runtimes, eg. python3.12 and python3.13.
 
 ## Fonts
 
@@ -24,7 +24,7 @@ Run `make build/ghostscript-layer.zip` to build the layer.
 
 Build the layer with:
 
-    $ make build/weasyprint-layer-python3.12.zip
+    $ make build/weasyprint-layer-python3.12-x86_64.zip
 
 To test your build:
 
@@ -42,7 +42,7 @@ Deploy layer:
     $ aws lambda publish-layer-version \
         --region <region> \
         --layer-name <name> \
-        --zip-file fileb://build/weasyprint-layer-python3.12.zip
+        --zip-file fileb://build/weasyprint-layer-python3.12-x86_64.zip
 
 Lambda must be configured with these env vars:
 
@@ -50,11 +50,11 @@ Lambda must be configured with these env vars:
     FONTCONFIG_PATH="/opt/fonts"
     XDG_DATA_DIRS="/opt/lib"
 
-If you are using the release zip files ensure your Lambda instruction set architecture is set to `x86_64` and not `arm64`.
+arm64 is also supported! Use the arm64 zip under Releases or build using "make build/weasyprint-layer-python3.12-arm64.zip"
 
 To build a layer for python3.13 runime use:
 
-    RUNTIME=3.13 make build/weasyprint-layer-python3.13.zip
+    RUNTIME=3.13 make build/weasyprint-layer-python3.13-x86_64.zip
 
 ### Docker Lambda
 

--- a/weasyprint/Makefile
+++ b/weasyprint/Makefile
@@ -1,8 +1,10 @@
-PLATFORM ?= linux/arm64
-ifeq ($(PLATFORM), linux/arm64)
+ARCH ?= x86_64
+ifeq ($(ARCH), arm64)
  RIE_BIN=aws-lambda-rie-arm64
+ PLATFORM=linux/arm64
 else
  RIE_BIN=aws-lambda-rie
+ PLATFORM=linux/amd64
 endif
 
 ${RIE_BIN}/aws-lambda-rie:

--- a/weasyprint/Makefile
+++ b/weasyprint/Makefile
@@ -1,4 +1,4 @@
-PLATFORM ?= linux/amd64
+PLATFORM ?= linux/arm64
 ifeq ($(PLATFORM), linux/arm64)
  RIE_BIN=aws-lambda-rie-arm64
 else


### PR DESCRIPTION
WeasyPrint works great on Arm64 on Python 3.12 and 3.13. I did need set LD_LIBRARY_PATH="/opt/lib" in the environment variables. GDK_PIXBUF_MODULE_FILE and XDG_DATA_DIRS are not required.

weasyprint-64.0 build zips: https://github.com/TheJuki/cloud-print-utils/releases/tag/weasyprint-64.0