### PR TITLE
Add Python 3.14 support for WeasyPrint Lambda layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build WeasyPrint
     strategy:
       matrix:
-        version: ["3.12", "3.13"]
+        version: ["3.12", "3.13", "3.14"]
         arch: ["x86_64", "arm64"]
     runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     env:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a collection of AWS Lambda layers and functions to render pdf documents and images from HTML.
 
 Download layers from release section or build them yourself (requires: make, docker, zip, unzip, jq).
-The layers support only Amazon Linux 2023 runtimes, eg. python3.12 and python3.13.
+The layers support only Amazon Linux 2023 runtimes, eg. python3.12, python3.13, and python3.14.
 
 ## Fonts
 
@@ -51,9 +51,10 @@ Lambda must be configured with these env vars:
 
 arm64 is also supported! Use the arm64 zip under Releases or build using "ARCH=arm64 make build/weasyprint-layer-python3.12-arm64.zip"
 
-To build a layer for python3.13 runime use:
+To build a layer for python3.13 or python3.14 runtime use:
 
     RUNTIME=3.13 make build/weasyprint-layer-python3.13-x86_64.zip
+    RUNTIME=3.14 make build/weasyprint-layer-python3.14-x86_64.zip
 
 ### Docker Lambda
 


### PR DESCRIPTION
As AWS just released support for Python 3.14 runtime appropriate layers are required.  https://aws.amazon.com/blogs/compute/python-3-14-runtime-now-available-in-aws-lambda/

Changes:
- Updated README.md to include Python 3.14 in supported runtimes
- Added Python 3.14 to CI/CD build matrix
- Added build example for Python 3.14 runtime

For testing I build my own local layer and push to prod for my app by:
- Built layer with: make RUNTIME=3.14 ARCH=x86_64
- Layer size: ~37 MB (compressed)
- Deployed to AWS Lambda running Python 3.14
- Verified PDF generation with WeasyPrint 66.0 in production

Thanks for considering this PR, will be helpful for others wanting to update their runtimes.