### PR TITLE
Add optional WEASYPRINT_VERSION to pin the WeasyPrint install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 RUNTIME ?= 3.12
 ARCH ?= x86_64
 TEST_FILENAME ?= report.pdf
-DOCKER_RUN=docker run --rm --platform=${PLATFORM} -e RUNTIME_VERSION=${RUNTIME}
+WEASYPRINT_VERSION ?=
+DOCKER_RUN=docker run --rm --platform=${PLATFORM} -e RUNTIME_VERSION=${RUNTIME} -e WEASYPRINT_VERSION=${WEASYPRINT_VERSION}
 
 ifeq ($(ARCH), arm64)
  PLATFORM=linux/arm64

--- a/weasyprint/layer_builder.sh
+++ b/weasyprint/layer_builder.sh
@@ -45,7 +45,13 @@ $PIXBUF_BIN > /opt/lib/loaders.cache
 RUNTIME=$(grep AWS_EXECUTION_ENV "$LAMBDA_RUNTIME_DIR/bootstrap" | cut -d _ -f 5)
 export RUNTIME
 mkdir -p "/opt/python/lib/$RUNTIME/site-packages"
-python -m pip install "weasyprint" -t "/opt/python/lib/$RUNTIME/site-packages"
+# Pin the WeasyPrint version when WEASYPRINT_VERSION is set; otherwise install latest.
+if [ -n "$WEASYPRINT_VERSION" ]; then
+  WEASYPRINT_SPEC="weasyprint==$WEASYPRINT_VERSION"
+else
+  WEASYPRINT_SPEC="weasyprint"
+fi
+python -m pip install "$WEASYPRINT_SPEC" -t "/opt/python/lib/$RUNTIME/site-packages"
 
 cd /opt
 zip -r9 /out/layer.zip lib/* python/*


### PR DESCRIPTION
## What

Adds a `WEASYPRINT_VERSION` make variable that, when set, pins the layer's WeasyPrint install to that exact version:

```
make RUNTIME=3.14 ARCH=arm64 WEASYPRINT_VERSION=69.0
```

When unset it defaults to empty, so `pip install weasyprint` runs exactly as before. Existing builds are unaffected.

## Why

Today `weasyprint/layer_builder.sh` runs `pip install "weasyprint"` with no version, so every rebuild silently picks up whatever is latest on PyPI that day. There's no way to reproduce a layer at a known WeasyPrint version, and a routine rebuild can change rendering behaviour without anyone choosing the version. Pinning the version is useful for anyone who needs production PDF output to stay on a deliberate, reviewed version.

## Changes

- `Makefile`: add `WEASYPRINT_VERSION ?=` and pass it into the build container via `DOCKER_RUN`.
- `weasyprint/layer_builder.sh`: install `weasyprint==$WEASYPRINT_VERSION` when the variable is set, otherwise the bare `weasyprint` as before.

## Testing

Built on arm64 / Python 3.14:

- `make RUNTIME=3.14 ARCH=arm64 WEASYPRINT_VERSION=67.0` → log shows `Collecting weasyprint==67.0` and the resulting layer contains `weasyprint-67.0.dist-info`. 67.0 is older than the current latest (69.0), so this confirms the pin actually constrains the version rather than just installing latest.
- `make RUNTIME=3.14 ARCH=arm64` (no variable) → log shows `Collecting weasyprint` and installs the latest, exactly as before.
